### PR TITLE
FIX: Use correct trait for display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.4.3
+
+* Fix the `Display` implementation on `Guard` to correctly delegate to the
+  underlying `Display` implementation.
+
 # 0.4.2
 
 * The Access functionality ‒ ability to pass a handle to subpart of held data to

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -540,7 +540,7 @@ impl<'a, T: Debug + RefCnt> Debug for Guard<'a, T> {
     }
 }
 
-impl<'a, T: Debug + RefCnt> Display for Guard<'a, T> {
+impl<'a, T: Display + RefCnt> Display for Guard<'a, T> {
     fn fmt(&self, formatter: &mut Formatter) -> FmtResult {
         self.deref().fmt(formatter)
     }


### PR DESCRIPTION
The current implementation incorrectly delegates `Display` on `Guard` to the `Debug` implementation. It should instead delegate to the underlying `Display` implementation.