### PR TITLE
Document clone behavior of `ArcSwapAny`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -606,7 +606,8 @@ const YIELD_EVERY: usize = 16;
 /// An atomic storage for a reference counted smart pointer like [`Arc`] or `Option<Arc>`.
 ///
 /// This is a storage where a smart pointer may live. It can be read and written atomically from
-/// several threads, but doesn't act like a pointer itself.
+/// several threads, but doesn't act like a pointer itself. (If you clone an `ArcSwapAny`
+/// and then call `.swap(...)`, the original `ArcSwapAny` will still point to the old contents.)
 ///
 /// One can be created [`from`] an [`Arc`]. To get the pointer back, use the
 /// [`load`](#method.load).


### PR DESCRIPTION
I'm not sure if this should be self-evident, but I struggled for a few hours to make my code correct, until I realized that `ArcSwap` itself does not behave like an `Arc` and that it will copy the state when cloning. (I'm not sure where this idea came from, probably because it has `Arc` in its name and because it wraps an `Arc`, so I assumed the clone semantics to be like `Arc`.)

If you don't think this change is needed, feel free to close the PR!