### PR TITLE
Implement Guard::from_inner

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -480,12 +480,16 @@ pub struct Guard<'l, T: RefCnt> {
 }
 
 impl<'a, T: RefCnt> Guard<'a, T> {
-    /// Turns the given guard into an unprotected, independent one.
+    /// Converts it into the held value.
     ///
-    /// It'll not hold any locks, will have no debts and will contain full-featured value inside
-    /// that even can outlive the ArcSwap it originated from.
+    /// This, on occasion, may be a tiny bit faster than cloning the Arc or whatever is being held
+    /// inside.
+    // Associated function on purpose, because of deref
+    #[cfg_attr(feature = "cargo-clippy", allow(wrong_self_convention))]
     #[inline]
-    fn unprotected(mut lease: Self) -> Guard<'static, T> {
+    pub fn into_inner(mut lease: Self) -> T {
+        // Drop any debt and release any lock held by the given guard and return a
+        // full-featured value that even can outlive the ArcSwap it originated from.
         match mem::replace(&mut lease.protection, Protection::Unprotected) {
             // Not protected, nothing to unprotect.
             Protection::Unprotected => (),
@@ -505,29 +509,12 @@ impl<'a, T: RefCnt> Guard<'a, T> {
                 lock.unlock();
             }
         }
-        // The ptr::read & forget is something like a cheating move. We can't move it out, because
-        // we have a destructor and Rust doesn't allow us to do that.
-        let inner = ManuallyDrop::new(unsafe { ptr::read(lease.inner.deref()) });
-        mem::forget(lease);
-        Guard {
-            inner,
-            protection: Protection::Unprotected,
-        }
-    }
 
-    /// Converts it into the held value.
-    ///
-    /// This, on occasion, may be a tiny bit faster than cloning the Arc or whatever is being held
-    /// inside.
-    // Associated function on purpose, because of deref
-    #[cfg_attr(feature = "cargo-clippy", allow(wrong_self_convention))]
-    pub fn into_inner(lease: Self) -> T {
-        let unprotected = Guard::unprotected(lease);
         // The ptr::read & forget is something like a cheating move. We can't move it out, because
         // we have a destructor and Rust doesn't allow us to do that.
-        let res = unsafe { ptr::read(unprotected.inner.deref()) };
-        mem::forget(unprotected);
-        res
+        let inner = unsafe { ptr::read(lease.inner.deref()) };
+        mem::forget(lease);
+        inner
     }
 }
 
@@ -855,8 +842,14 @@ impl<T: RefCnt, S: LockStorage> ArcSwapAny<T, S> {
     /// ```
     #[inline]
     pub fn load(&self) -> Guard<'static, T> {
-        self.load_fallible()
-            .unwrap_or_else(|| Guard::unprotected(self.lock_internal(SignalSafety::Unsafe)))
+        self.load_fallible().unwrap_or_else(|| {
+            let locked = self.lock_internal(SignalSafety::Unsafe);
+            let full_value = Guard::into_inner(locked);
+            Guard {
+                inner: ManuallyDrop::new(full_value),
+                protection: Protection::Unprotected,
+            }
+        })
     }
 
     /// Replaces the value inside this instance.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -528,6 +528,18 @@ impl<'a, T: RefCnt> Guard<'a, T> {
     ///
     /// This can be useful on occasion to pass a specific object to code that expects or
     /// wants to store a Guard.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use arc_swap::{ArcSwap, Guard};
+    /// # use std::sync::Arc;
+    /// # let p = ArcSwap::from_pointee(42);
+    /// // Create two guards pointing to the same object
+    /// let g1 = p.load();
+    /// let g2 = Guard::from_inner(Arc::clone(&*g1));
+    /// # drop(g2);
+    /// ```
     pub fn from_inner(inner: T) -> Self {
         Guard {
             inner: ManuallyDrop::new(inner),


### PR DESCRIPTION
As discussed in #25, implement `Guard::from_inner`. I'm keeping the refactorings, because they actually let me use `Guard::from_inner` in the implementation of `load`.