### PR TITLE
Add serialize / deserialize features.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,6 +21,7 @@ dependencies = [
  "parking_lot",
  "proptest",
  "serde",
+ "serde_derive",
  "serde_json",
 ]
 
@@ -651,9 +652,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.118"
+version = "1.0.130"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c84d3526699cd55261af4b941e4e725444df67aa4f9e6a3564f18030d12672df"
+checksum = "d7bc1a1ab1961464eae040d96713baa5a724a8152c1222492465b54322ec508b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -679,9 +680,9 @@ checksum = "ae524f056d7d770e174287294f562e95044c68e88dec909a00d2094805db9d75"
 
 [[package]]
 name = "syn"
-version = "1.0.55"
+version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a571a711dddd09019ccc628e1b17fe87c59b09d513c06c026877aa708334f37a"
+checksum = "6498a9efc342871f91cc2d0d694c674368b4ceb40f62b65a7a08c3792935e702"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,6 +20,8 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "proptest",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -633,9 +635,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.118"
+version = "1.0.130"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06c64263859d87aa2eb554587e2d23183398d617427327cf2b3d0ed8c69e4800"
+checksum = "f12d06de37cf59146fbdecab66aa99f9fe4f78722e3607577a5375d66bd0c913"
 
 [[package]]
 name = "serde_cbor"
@@ -660,9 +662,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.60"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1500e84d27fe482ed1dc791a56eddc2f230046a040fa908c08bda1d9fb615779"
+checksum = "e466864e431129c7e0d3476b92f20458e5879919a0596c6472738d9fa2d342f8"
 dependencies = [
  "itoa",
  "ryu",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,11 @@ weak = []
 internal-test-strategies = []
 # Possibly some strategies we are experimenting with. Currently empty. No stability guarantees are included about them.
 experimental-strategies = []
+serialize = ["serde"]
+deserialize = ["serde"]
 
 [dependencies]
+serde = { version = "1.0.130", features = ["rc"], optional = true }
 
 [dev-dependencies]
 adaptive-barrier = "~0.1"
@@ -35,6 +38,7 @@ num_cpus = "~1"
 once_cell = "~1"
 parking_lot = "~0.11"
 proptest = "~0.10"
+serde_json = "1.0.69"
 
 [profile.bench]
 debug = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ num_cpus = "~1"
 once_cell = "~1"
 parking_lot = "~0.11"
 proptest = "~0.10"
+serde_derive = "1.0.130"
 serde_json = "1.0.69"
 
 [profile.bench]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,6 @@ weak = []
 internal-test-strategies = []
 # Possibly some strategies we are experimenting with. Currently empty. No stability guarantees are included about them.
 experimental-strategies = []
-serialize = ["serde"]
-deserialize = ["serde"]
 
 [dependencies]
 serde = { version = "1.0.130", features = ["rc"], optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,11 +131,11 @@ mod compile_fail_tests;
 mod debt;
 pub mod docs;
 mod ref_cnt;
+#[cfg(feature = "serde")]
+mod serde;
 pub mod strategy;
 #[cfg(feature = "weak")]
 mod weak;
-#[cfg(feature="serde")]
-mod serde;
 
 use std::borrow::Borrow;
 use std::fmt::{Debug, Display, Formatter, Result as FmtResult};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,7 +134,7 @@ mod ref_cnt;
 pub mod strategy;
 #[cfg(feature = "weak")]
 mod weak;
-#[cfg(any(feature="serialize",feature="deserialize"))]
+#[cfg(feature="serde")]
 mod serde;
 
 use std::borrow::Borrow;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,6 +134,8 @@ mod ref_cnt;
 pub mod strategy;
 #[cfg(feature = "weak")]
 mod weak;
+#[cfg(any(feature="serialize",feature="deserialize"))]
+mod serde;
 
 use std::borrow::Borrow;
 use std::fmt::{Debug, Display, Formatter, Result as FmtResult};

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -128,7 +128,7 @@ mod tests {
     #[test]
     fn test_deserialize_option_none() {
         let str = "null";
-        let data = serde_json::from_str::<ArcSwapOption<Foo>>(&str).unwrap();
+        let data = serde_json::from_str::<ArcSwapOption<Foo>>(str).unwrap();
 
         assert_eq!(data.load_full(), None);
     }

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -1,10 +1,6 @@
-#[cfg(feature = "serialize")]
-use serde::{Serialize, Serializer};
-#[cfg(feature = "deserialize")]
-use serde::{Deserialize, Deserializer};
+use serde::{Serialize, Serializer, Deserialize, Deserializer};
 use crate::{RefCnt, ArcSwapAny, Strategy};
 
-#[cfg(feature = "serialize")]
 impl<T, S> Serialize for ArcSwapAny<T, S>
     where
         T: RefCnt + Serialize,
@@ -15,7 +11,6 @@ impl<T, S> Serialize for ArcSwapAny<T, S>
     }
 }
 
-#[cfg(feature = "deserialize")]
 impl<'de, T, S> Deserialize<'de> for ArcSwapAny<T, S>
     where
         T: RefCnt + Deserialize<'de>,

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -24,50 +24,81 @@ impl<'de, T, S> Deserialize<'de> for ArcSwapAny<T, S>
 #[cfg(test)]
 mod tests {
     use crate::{ArcSwapOption, ArcSwap};
+    use serde_derive::{Serialize, Deserialize};
 
-    #[derive(serde::Serialize, PartialEq, Eq, serde::Deserialize)]
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize,)]
     struct Foo {
         field0: usize,
         field1: String,
     }
 
     #[test]
-    fn test_serialize_deserialize() {
-        let data = Foo {
+    fn test_serialize() {
+        let data_orig = Foo {
             field0: usize::MAX,
             field1: format!("FOO_{}", i128::MIN),
         };
-        let data = ArcSwap::from_pointee(data);
+        let data = ArcSwap::from_pointee(data_orig.clone());
 
         let data_str = serde_json::to_string(&data).unwrap();
-        let data_new = serde_json::from_str::<ArcSwap<Foo>>(&data_str).unwrap();
+        let data_deser = serde_json::from_str::<Foo>(&data_str).unwrap();
 
-        assert_eq!(data.load().as_ref(), data_new.load().as_ref());
+        assert_eq!(data_deser, data_orig);
     }
 
     #[test]
-    fn test_serialize_deserialize_option() {
-        let data = Foo {
+    fn test_deserialize() {
+        let field0 = usize::MAX;
+        let field1 = format!("FOO_{}", usize::MIN);
+
+        let str = format!(r#"{{"field0":{},"field1":"{}"}}"#, field0, field1);
+        let data = serde_json::from_str::<ArcSwap<Foo>>(&str).unwrap();
+
+        assert_eq!(data.load().field0, field0);
+        assert_eq!(data.load().field1, field1);
+    }
+
+    #[test]
+    fn test_serialize_option() {
+        let data_orig = Foo {
             field0: usize::MAX,
             field1: format!("FOO_{}", i128::MIN),
         };
-        let data = ArcSwapOption::from_pointee(data);
+        let data = ArcSwapOption::from_pointee(data_orig.clone());
 
         let data_str = serde_json::to_string(&data).unwrap();
-        let data_new = serde_json::from_str::<ArcSwapOption<Foo>>(&data_str).unwrap();
+        let data_deser = serde_json::from_str::<Foo>(&data_str).unwrap();
 
-        assert_eq!(data.load().as_ref(), data_new.load().as_ref());
+        assert_eq!(data_deser, data_orig);
     }
 
     #[test]
-    fn test_serialize_deserialize_option_none() {
+    fn test_deserialize_option() {
+        let field0 = usize::MAX;
+        let field1 = format!("FOO_{}", usize::MIN);
+
+        let str = format!(r#"{{"field0":{},"field1":"{}"}}"#, field0, field1);
+        let data = serde_json::from_str::<ArcSwapOption<Foo>>(&str).unwrap();
+
+        assert_eq!(data.load_full().unwrap().field0, field0);
+        assert_eq!(data.load_full().unwrap().field1, field1);
+    }
+
+    #[test]
+    fn test_serialize_option_none() {
         let data = ArcSwapOption::<Foo>::from_pointee(None);
 
         let data_str = serde_json::to_string(&data).unwrap();
-        let data_new = serde_json::from_str::<ArcSwapOption<Foo>>(&data_str).unwrap();
+        let data_deser = serde_json::from_str::<Option<Foo>>(&data_str).unwrap();
 
-        assert_eq!(data.load().as_ref(), None);
-        assert_eq!(data_new.load().as_ref(), None);
-        assert_eq!(data.load().as_ref(), data_new.load().as_ref());
+        assert_eq!(data_deser, None);
+    }
+
+    #[test]
+    fn test_deserialize_option_none() {
+        let str = "null";
+        let data = serde_json::from_str::<ArcSwapOption<Foo>>(&str).unwrap();
+
+        assert_eq!(data.load_full(), None);
     }
 }

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -1,0 +1,111 @@
+#[cfg(feature = "serialize")]
+use serde::{Serialize, Serializer};
+#[cfg(feature = "deserialize")]
+use serde::{Deserialize, Deserializer};
+use crate::{RefCnt, ArcSwapAny, Strategy};
+
+#[cfg(feature = "serialize")]
+/// # Examples
+///
+/// ```rust
+/// use arc_swap::ArcSwap;
+///
+/// #[derive(serde::Serialize)]
+/// struct Foo {
+///     field0: usize,
+///     field1: String,
+/// }
+///
+/// let data = Foo {
+///     field0: 123,
+///     field1: "123".to_owned(),
+/// };
+///
+/// let data_json = serde_json::to_string(&data).unwrap();
+/// println!("{}", data_json);
+/// ```
+impl<T, S> Serialize for ArcSwapAny<T, S>
+    where
+        T: RefCnt + Serialize,
+        S: Strategy<T>,
+{
+    fn serialize<Ser: Serializer>(&self, serializer: Ser) -> Result<Ser::Ok, Ser::Error> {
+        self.load().serialize(serializer)
+    }
+}
+
+#[cfg(feature = "deserialize")]
+/// # Examples
+///
+/// ```rust
+/// use arc_swap::ArcSwap;
+///
+/// #[derive(serde::Deserialize)]
+/// struct Foo {
+///     field0: usize,
+///     field1: String,
+/// }
+///
+/// let data = serde_json::from_str::<ArcSwap<Foo>>(r#"{"field0":123,"field1":"123"}"#).unwrap();
+/// println!("{:?}", data);
+/// ```
+impl<'de, T, S> Deserialize<'de> for ArcSwapAny<T, S>
+    where
+        T: RefCnt + Deserialize<'de>,
+        S: Strategy<T> + Default,
+{
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        Ok(Self::from(T::deserialize(deserializer)?))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{ArcSwapOption, ArcSwap};
+
+    #[derive(serde::Serialize, PartialEq, Eq, serde::Deserialize)]
+    struct Foo {
+        field0: usize,
+        field1: String,
+    }
+
+    #[test]
+    fn test_serialize_deserialize() {
+        let data = Foo {
+            field0: usize::MAX,
+            field1: format!("FOO_{}", i128::MIN),
+        };
+        let data = ArcSwap::from_pointee(data);
+
+        let data_str = serde_json::to_string(&data).unwrap();
+        let data_new = serde_json::from_str::<ArcSwap<Foo>>(&data_str).unwrap();
+
+        assert_eq!(data.load().as_ref(), data_new.load().as_ref());
+    }
+
+    #[test]
+    fn test_serialize_deserialize_option() {
+        let data = Foo {
+            field0: usize::MAX,
+            field1: format!("FOO_{}", i128::MIN),
+        };
+        let data = ArcSwapOption::from_pointee(data);
+
+        let data_str = serde_json::to_string(&data).unwrap();
+        let data_new = serde_json::from_str::<ArcSwapOption<Foo>>(&data_str).unwrap();
+
+        assert_eq!(data.load().as_ref(), data_new.load().as_ref());
+    }
+
+    #[test]
+    fn test_serialize_deserialize_option_none() {
+        let data = ArcSwapOption::<Foo>::from_pointee(None);
+
+        let data_str = serde_json::to_string(&data).unwrap();
+        let data_new = serde_json::from_str::<ArcSwapOption<Foo>>(&data_str).unwrap();
+
+        assert_eq!(data.load().as_ref(), None);
+        assert_eq!(data_new.load().as_ref(), None);
+        assert_eq!(data.load().as_ref(), data_new.load().as_ref());
+    }
+}

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -1,10 +1,10 @@
-use serde::{Serialize, Serializer, Deserialize, Deserializer};
-use crate::{RefCnt, ArcSwapAny, Strategy};
+use crate::{ArcSwapAny, RefCnt, Strategy};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 impl<T, S> Serialize for ArcSwapAny<T, S>
-    where
-        T: RefCnt + Serialize,
-        S: Strategy<T>,
+where
+    T: RefCnt + Serialize,
+    S: Strategy<T>,
 {
     fn serialize<Ser: Serializer>(&self, serializer: Ser) -> Result<Ser::Ok, Ser::Error> {
         self.load().serialize(serializer)
@@ -12,9 +12,9 @@ impl<T, S> Serialize for ArcSwapAny<T, S>
 }
 
 impl<'de, T, S> Deserialize<'de> for ArcSwapAny<T, S>
-    where
-        T: RefCnt + Deserialize<'de>,
-        S: Strategy<T> + Default,
+where
+    T: RefCnt + Deserialize<'de>,
+    S: Strategy<T> + Default,
 {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         Ok(Self::from(T::deserialize(deserializer)?))
@@ -23,16 +23,16 @@ impl<'de, T, S> Deserialize<'de> for ArcSwapAny<T, S>
 
 #[cfg(test)]
 mod tests {
-    use crate::{ArcSwapOption, ArcSwap};
-    use serde_derive::{Serialize, Deserialize};
+    use crate::{ArcSwap, ArcSwapOption};
+    use serde_derive::{Deserialize, Serialize};
 
-    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize,)]
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
     struct Foo {
         field0: usize,
         field1: String,
     }
 
-    #[derive(Debug, Serialize, Deserialize,)]
+    #[derive(Debug, Serialize, Deserialize)]
     struct Bar {
         field0: ArcSwap<usize>,
         field1: ArcSwapOption<String>,

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -5,25 +5,6 @@ use serde::{Deserialize, Deserializer};
 use crate::{RefCnt, ArcSwapAny, Strategy};
 
 #[cfg(feature = "serialize")]
-/// # Examples
-///
-/// ```rust
-/// use arc_swap::ArcSwap;
-///
-/// #[derive(serde::Serialize)]
-/// struct Foo {
-///     field0: usize,
-///     field1: String,
-/// }
-///
-/// let data = Foo {
-///     field0: 123,
-///     field1: "123".to_owned(),
-/// };
-///
-/// let data_json = serde_json::to_string(&data).unwrap();
-/// println!("{}", data_json);
-/// ```
 impl<T, S> Serialize for ArcSwapAny<T, S>
     where
         T: RefCnt + Serialize,
@@ -35,20 +16,6 @@ impl<T, S> Serialize for ArcSwapAny<T, S>
 }
 
 #[cfg(feature = "deserialize")]
-/// # Examples
-///
-/// ```rust
-/// use arc_swap::ArcSwap;
-///
-/// #[derive(serde::Deserialize)]
-/// struct Foo {
-///     field0: usize,
-///     field1: String,
-/// }
-///
-/// let data = serde_json::from_str::<ArcSwap<Foo>>(r#"{"field0":123,"field1":"123"}"#).unwrap();
-/// println!("{:?}", data);
-/// ```
 impl<'de, T, S> Deserialize<'de> for ArcSwapAny<T, S>
     where
         T: RefCnt + Deserialize<'de>,


### PR DESCRIPTION
#46 

Greetings,

Realization is optional (through features). For me such feature needed to get rid of tons of manual Deserializations / Serializations like this:
```rust
use arc_swap::ArcSwap;

#[derive(Debug, serde::Serialize, serde::Deserialize)]
struct Foo {
    field0: ArcSwap<usize>,
    field1: ArcSwap<String>,
}

fn main() {
    let data = Foo {
        field0: ArcSwap::from_pointee(123),
        field1: ArcSwap::from_pointee("FOO".to_owned()),
    };

    println!("{}", serde_json::to_string(&data).unwrap());
}
```