### PR TITLE
Use serde_test for unit test instead of serde_json.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,7 +22,7 @@ dependencies = [
  "proptest",
  "serde",
  "serde_derive",
- "serde_json",
+ "serde_test",
 ]
 
 [[package]]
@@ -669,6 +669,15 @@ checksum = "e466864e431129c7e0d3476b92f20458e5879919a0596c6472738d9fa2d342f8"
 dependencies = [
  "itoa",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_test"
+version = "1.0.130"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d82178225dbdeae2d5d190e8649287db6a3a32c6d24da22ae3146325aa353e4c"
+dependencies = [
  "serde",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ once_cell = "~1"
 parking_lot = "~0.11"
 proptest = "~0.10"
 serde_derive = "1.0.130"
-serde_json = "1.0.69"
+serde_test = "1.0.130"
 
 [profile.bench]
 debug = true

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -85,6 +85,8 @@ mod tests {
                     len: 2,
                 },
                 Token::Str("field0"),
+                #[cfg(target_pointer_width = "16")]
+                Token::U16(u16::MAX),
                 #[cfg(target_pointer_width = "32")]
                 Token::U32(u32::MAX),
                 #[cfg(target_pointer_width = "64")]
@@ -107,6 +109,8 @@ mod tests {
                     len: 2,
                 },
                 Token::Str("field0"),
+                #[cfg(target_pointer_width = "16")]
+                Token::U16(u16::MAX),
                 #[cfg(target_pointer_width = "32")]
                 Token::U32(u32::MAX),
                 #[cfg(target_pointer_width = "64")]
@@ -138,6 +142,8 @@ mod tests {
                     len: 2,
                 },
                 Token::Str("field0"),
+                #[cfg(target_pointer_width = "16")]
+                Token::U16(u16::MAX),
                 #[cfg(target_pointer_width = "32")]
                 Token::U32(u32::MAX),
                 #[cfg(target_pointer_width = "64")]

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -23,113 +23,136 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::{ArcSwap, ArcSwapOption};
+    use crate::{ArcSwap, ArcSwapAny, ArcSwapOption, RefCnt};
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
     use serde_derive::{Deserialize, Serialize};
+    use serde_test::{assert_tokens, Token};
+    use std::sync::Arc;
 
-    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    #[derive(Debug)]
+    struct ArcSwapAnyEq<T: RefCnt>(ArcSwapAny<T>);
+    impl<T: RefCnt + PartialEq> PartialEq for ArcSwapAnyEq<T> {
+        fn eq(&self, other: &Self) -> bool {
+            self.0.load().eq(&other.0.load())
+        }
+    }
+    impl<T: RefCnt + PartialEq> Eq for ArcSwapAnyEq<T> {}
+    impl<T: RefCnt + Serialize> Serialize for ArcSwapAnyEq<T> {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            self.0.load().serialize(serializer)
+        }
+    }
+    impl<'de, T: RefCnt + Deserialize<'de>> Deserialize<'de> for ArcSwapAnyEq<T> {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            let inner = T::deserialize(deserializer)?;
+            Ok(Self(ArcSwapAny::new(inner)))
+        }
+    }
+
+    #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
     struct Foo {
         field0: usize,
         field1: String,
     }
 
-    #[derive(Debug, Serialize, Deserialize)]
+    #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
     struct Bar {
-        field0: ArcSwap<usize>,
-        field1: ArcSwapOption<String>,
+        field0: ArcSwapAnyEq<Arc<usize>>,
+        field1: ArcSwapAnyEq<Option<Arc<String>>>,
     }
 
     #[test]
-    fn test_serialize() {
-        let data_orig = Foo {
-            field0: usize::MAX,
-            field1: format!("FOO_{}", i128::MIN),
-        };
-        let data = ArcSwap::from_pointee(data_orig.clone());
-        let data_str = serde_json::to_string(&data).unwrap();
-        let data_deser = serde_json::from_str::<Foo>(&data_str).unwrap();
-        assert_eq!(data_deser, data_orig);
-
-        let data_orig = Bar {
-            field0: ArcSwap::from_pointee(usize::MAX),
-            field1: ArcSwapOption::from_pointee(format!("FOO_{}", i128::MIN)),
-        };
-        let data_str = serde_json::to_string(&data_orig).unwrap();
-        let data_deser = serde_json::from_str::<Bar>(&data_str).unwrap();
-        assert_eq!(data_deser.field0.load_full(), data_orig.field0.load_full());
-        assert_eq!(data_deser.field1.load_full(), data_orig.field1.load_full());
-
-        let data_orig = Bar {
-            field0: ArcSwap::from_pointee(usize::MAX),
-            field1: ArcSwapOption::from_pointee(None),
-        };
-        let data_str = serde_json::to_string(&data_orig).unwrap();
-        let data_deser = serde_json::from_str::<Bar>(&data_str).unwrap();
-        assert_eq!(data_deser.field0.load_full(), data_orig.field0.load_full());
-        assert_eq!(data_deser.field1.load_full(), data_orig.field1.load_full());
-    }
-
-    #[test]
-    fn test_deserialize() {
+    fn test_serialize_deserialize() {
         let field0 = usize::MAX;
-        let field1 = format!("FOO_{}", usize::MIN);
+        let field1 = "FOO_-0123456789";
 
-        let str = format!(r#"{{"field0":{},"field1":"{}"}}"#, field0, field1);
-        let data = serde_json::from_str::<ArcSwap<Foo>>(&str).unwrap();
-        assert_eq!(data.load().field0, field0);
-        assert_eq!(data.load().field1, field1);
-
-        let str = format!(r#"{{"field0":{},"field1":"{}"}}"#, field0, field1);
-        let data = serde_json::from_str::<Bar>(&str).unwrap();
-        assert_eq!(data.field0.load_full().as_ref(), &field0);
-        assert_eq!(data.field1.load_full().as_deref(), Some(&field1));
-
-        let str = format!(r#"{{"field0":{}}}"#, field0);
-        let data = serde_json::from_str::<Bar>(&str).unwrap();
-        assert_eq!(data.field0.load_full().as_ref(), &field0);
-        assert_eq!(data.field1.load_full().as_deref(), None);
-    }
-
-    #[test]
-    fn test_serialize_option() {
         let data_orig = Foo {
-            field0: usize::MAX,
-            field1: format!("FOO_{}", i128::MIN),
+            field0,
+            field1: field1.to_string(),
         };
-        let data = ArcSwapOption::from_pointee(data_orig.clone());
+        let data = ArcSwapAnyEq(ArcSwap::from_pointee(data_orig));
+        assert_tokens(
+            &data,
+            &[
+                Token::Struct {
+                    name: "Foo",
+                    len: 2,
+                },
+                Token::Str("field0"),
+                #[cfg(target_pointer_width = "32")]
+                Token::U32(u32::MAX),
+                #[cfg(target_pointer_width = "64")]
+                Token::U64(u64::MAX),
+                Token::Str("field1"),
+                Token::String(field1),
+                Token::StructEnd,
+            ],
+        );
 
-        let data_str = serde_json::to_string(&data).unwrap();
-        let data_deser = serde_json::from_str::<Foo>(&data_str).unwrap();
-
-        assert_eq!(data_deser, data_orig);
+        let data = Bar {
+            field0: ArcSwapAnyEq(ArcSwap::from_pointee(field0)),
+            field1: ArcSwapAnyEq(ArcSwapOption::from_pointee(field1.to_string())),
+        };
+        assert_tokens(
+            &data,
+            &[
+                Token::Struct {
+                    name: "Bar",
+                    len: 2,
+                },
+                Token::Str("field0"),
+                #[cfg(target_pointer_width = "32")]
+                Token::U32(u32::MAX),
+                #[cfg(target_pointer_width = "64")]
+                Token::U64(u64::MAX),
+                Token::Str("field1"),
+                Token::Some,
+                Token::String(field1),
+                Token::StructEnd,
+            ],
+        );
     }
 
     #[test]
-    fn test_deserialize_option() {
+    fn test_serialize_deserialize_option() {
         let field0 = usize::MAX;
-        let field1 = format!("FOO_{}", usize::MIN);
+        let field1 = "FOO_-0123456789";
 
-        let str = format!(r#"{{"field0":{},"field1":"{}"}}"#, field0, field1);
-        let data = serde_json::from_str::<ArcSwapOption<Foo>>(&str).unwrap();
-
-        assert_eq!(data.load_full().unwrap().field0, field0);
-        assert_eq!(data.load_full().unwrap().field1, field1);
+        let data_orig = Foo {
+            field0,
+            field1: field1.to_string(),
+        };
+        let data = ArcSwapAnyEq(ArcSwapOption::from_pointee(data_orig));
+        assert_tokens(
+            &data,
+            &[
+                Token::Some,
+                Token::Struct {
+                    name: "Foo",
+                    len: 2,
+                },
+                Token::Str("field0"),
+                #[cfg(target_pointer_width = "32")]
+                Token::U32(u32::MAX),
+                #[cfg(target_pointer_width = "64")]
+                Token::U64(u64::MAX),
+                Token::Str("field1"),
+                Token::String(field1),
+                Token::StructEnd,
+            ],
+        );
     }
 
     #[test]
-    fn test_serialize_option_none() {
-        let data = ArcSwapOption::<Foo>::from_pointee(None);
+    fn test_serialize_deserialize_option_none() {
+        let data = ArcSwapAnyEq(ArcSwapOption::<Foo>::from_pointee(None));
 
-        let data_str = serde_json::to_string(&data).unwrap();
-        let data_deser = serde_json::from_str::<Option<Foo>>(&data_str).unwrap();
-
-        assert_eq!(data_deser, None);
-    }
-
-    #[test]
-    fn test_deserialize_option_none() {
-        let str = "null";
-        let data = serde_json::from_str::<ArcSwapOption<Foo>>(str).unwrap();
-
-        assert_eq!(data.load_full(), None);
+        assert_tokens(&data, &[Token::None]);
     }
 }


### PR DESCRIPTION
Hello again!

These PRs have no new functionality, but may be implementing a more idiomatic way to test `serde::{Serialize, Deserialize}` by `serde_test` crate.

But because `ArcSwapAny` doesn't have  `Eq`, `PartialEq` traits implementation, in this case I'm using some wrapper around it.

What do you think about this ?