### PR TITLE
Fix stacked-borrows violations, and re-enable SB in CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -231,7 +231,7 @@ jobs:
       - name: Run miri
         env:
           PROPTEST_CASES: "10"
-          MIRIFLAGS: "-Zmiri-disable-isolation"
+          MIRIFLAGS: "-Zmiri-disable-isolation -Zmiri-permissive-provenance"
         run: cargo miri test --all-features
 
   thread_sanitizer-MacOS:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -231,8 +231,7 @@ jobs:
       - name: Run miri
         env:
           PROPTEST_CASES: "10"
-          # TODO: Do something with the stacked borrows. Figure out what it means.
-          MIRIFLAGS: "-Zmiri-disable-isolation -Zmiri-disable-stacked-borrows"
+          MIRIFLAGS: "-Zmiri-disable-isolation"
         run: cargo miri test --all-features
 
   thread_sanitizer-MacOS:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,6 +20,7 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "proptest",
+ "rustversion",
  "serde",
  "serde_derive",
  "serde_json",
@@ -596,6 +597,12 @@ checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
  "semver",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97477e48b4cf8603ad5f7aaf897467cf42ab4218a38ef76fb14c2d6773a6d6a8"
 
 [[package]]
 name = "rusty-fork"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ internal-test-strategies = []
 experimental-strategies = []
 
 [dependencies]
+rustversion = "1.0.9"
 serde = { version = "1", features = ["rc"], optional = true }
 
 [dev-dependencies]

--- a/src/ref_cnt.rs
+++ b/src/ref_cnt.rs
@@ -91,8 +91,14 @@ unsafe impl<T> RefCnt for Arc<T> {
     fn into_ptr(me: Arc<T>) -> *mut T {
         Arc::into_raw(me) as *mut T
     }
+    #[rustversion::since(1.45)]
     fn as_ptr(me: &Arc<T>) -> *mut T {
         Arc::as_ptr(me) as *mut T
+    }
+    #[rustversion::before(1.45)]
+    fn as_ptr(me: &Arc<T>) -> *mut T {
+        // This causes UB, but the safe way is only stable since 1.45
+        me as &T as *const T as *mut T
     }
     unsafe fn from_ptr(ptr: *const T) -> Arc<T> {
         Arc::from_raw(ptr)
@@ -104,7 +110,13 @@ unsafe impl<T> RefCnt for Rc<T> {
     fn into_ptr(me: Rc<T>) -> *mut T {
         Rc::into_raw(me) as *mut T
     }
+    #[rustversion::since(1.45)]
     fn as_ptr(me: &Rc<T>) -> *mut T {
+        Rc::as_ptr(me) as *mut T
+    }
+    #[rustversion::before(1.45)]
+    fn as_ptr(me: &Rc<T>) -> *mut T {
+        // This causes UB, but the safe way is only stable since 1.45
         me as &T as *const T as *mut T
     }
     unsafe fn from_ptr(ptr: *const T) -> Rc<T> {

--- a/src/ref_cnt.rs
+++ b/src/ref_cnt.rs
@@ -92,7 +92,7 @@ unsafe impl<T> RefCnt for Arc<T> {
         Arc::into_raw(me) as *mut T
     }
     fn as_ptr(me: &Arc<T>) -> *mut T {
-        me as &T as *const T as *mut T
+        Arc::as_ptr(me) as *mut T
     }
     unsafe fn from_ptr(ptr: *const T) -> Arc<T> {
         Arc::from_raw(ptr)


### PR DESCRIPTION
`Arc::as_ptr` avoids reborrowing the memory location as `SharedReadOnly`.
This PR also re-enables stacked borrows checks in CI (adjusting the params of some tests to improve their performance).
`-Zmiri-permissive-provenance` is set to silence warnings about integer/pointer casts.

Locally, Miri reported a data race error but I was not able to reproduce this in the CI, so I'm unsure if it's a false positive.