### PR TITLE
no_std support, more minimal and less intrusive version

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Run cargo-tarpaulin
         uses: actions-rs/tarpaulin@v0.1
         with:
-          args: '--all-features --run-types Doctests,Tests'
+          args: '--features weak,internal-test-strategies,experimental-strategies --run-types Doctests,Tests'
           timeout: 120
 
       - name: Upload to codecov.io

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -46,7 +46,7 @@ jobs:
           RUST_VERSION: ${{ matrix.rust }}
           OS: ${{ matrix.os }}
           RUSTFLAGS: -D warnings
-        run: cargo test --all-features
+        run: cargo test --features weak,internal-test-strategies,experimental-strategies
 
   big-tests:
     name: Run the big ignored tests
@@ -68,7 +68,7 @@ jobs:
       - name: Build & test
         env:
           RUSTFLAGS: -D warnings
-        run: cargo test --all-features --release -- --ignored
+        run: cargo test --features weak,internal-test-strategies,experimental-strategies --release -- --ignored
 
   bits32:
     name: 32bit tests
@@ -91,7 +91,7 @@ jobs:
       - name: Build & test
         env:
           RUSTFLAGS: -D warnings
-        run: cargo test --all-features --target x86_64-unknown-linux-musl
+        run: cargo test --features weak,internal-test-strategies,experimental-strategies --target x86_64-unknown-linux-musl
 
   rustfmt:
     name: Check formatting
@@ -127,7 +127,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Check links
-        run: cargo rustdoc --all-features -- -D warnings
+        run: cargo rustdoc --features weak,internal-test-strategies,experimental-strategies -- -D warnings
 
   clippy:
     name: Clippy lints
@@ -148,7 +148,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Run clippy linter
-        run: cargo clippy --all --all-features --tests -- -D clippy::all -D warnings
+        run: cargo clippy --all --features weak,internal-test-strategies,experimental-strategies --tests -- -D clippy::all -D warnings
 
   bench:
     name: Verify benchmarks compile
@@ -168,7 +168,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Run clippy linter
-        run: cargo test --all --release --benches --all-features
+        run: cargo test --all --release --benches --features weak,internal-test-strategies,experimental-strategies
 
   semi-ancient:
     name: Check it compiles on old Rust (1.45.0)
@@ -188,7 +188,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Run check
-        run: rm Cargo.lock && cargo check --all-features
+        run: rm Cargo.lock && cargo check --features weak,internal-test-strategies,experimental-strategies
 
   ancient:
     name: Check it compiles on old Rust (1.31.0)
@@ -232,7 +232,7 @@ jobs:
         env:
           PROPTEST_CASES: "10"
           MIRIFLAGS: "-Zmiri-disable-isolation -Zmiri-permissive-provenance"
-        run: cargo miri test --all-features
+        run: cargo miri test --features weak,internal-test-strategies,experimental-strategies
 
   thread_sanitizer-MacOS:
     name: Thread Sanitizer checks MacOS

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -210,6 +210,26 @@ jobs:
       - name: Run check
         run: rm Cargo.lock && cargo check
 
+  experimental_thread_local:
+    name: Build with experimental-thread-local
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          profile: minimal
+          default: true
+
+      - name: Restore cache
+        uses: Swatinem/rust-cache@v1
+
+      - name: Build
+        run: cargo build --no-default-features --features weak,experimental-thread-local
+
   miri:
     name: Miri checks
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -211,7 +211,7 @@ jobs:
         run: rm Cargo.lock && cargo check
 
   experimental_thread_local:
-    name: Build with experimental-thread-local
+    name: Test with experimental-thread-local
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -227,8 +227,10 @@ jobs:
       - name: Restore cache
         uses: Swatinem/rust-cache@v1
 
-      - name: Build
-        run: cargo build --no-default-features --features weak,experimental-thread-local
+      - name: Build & test
+        env:
+          RUSTFLAGS: -D warnings
+        run: cargo test --no-default-features --features weak,experimental-thread-local
 
   miri:
     name: Miri checks

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ internal-test-strategies = []
 # Possibly some strategies we are experimenting with. Currently empty. No stability guarantees are included about them.
 experimental-strategies = []
 # Use the nightly "thread_local" feature, to allow no_std builds.
-# Also makes use of nightly feature "lazy_cell". Drops support for std::sync::RwLock.
 experimental-thread-local = []
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,9 @@ weak = []
 internal-test-strategies = []
 # Possibly some strategies we are experimenting with. Currently empty. No stability guarantees are included about them.
 experimental-strategies = []
-# Allow running in no_std environments (no support for RwLock, Rust Nightly only)
-no-std = []
+# Use the nightly "thread_local" feature, to allow no_std builds.
+# Also makes use of nightly feature "lazy_cell". Drops support for std::sync::RwLock.
+experimental-thread-local = []
 
 [dependencies]
 serde = { version = "1", features = ["rc"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,8 @@ weak = []
 internal-test-strategies = []
 # Possibly some strategies we are experimenting with. Currently empty. No stability guarantees are included about them.
 experimental-strategies = []
+# Allow running in no_std environments (no support for RwLock, Rust Nightly only)
+no-std = []
 
 [dependencies]
 serde = { version = "1", features = ["rc"], optional = true }

--- a/ci-check.sh
+++ b/ci-check.sh
@@ -12,5 +12,5 @@ fi
 # Allow some warnings on the very old compiler.
 export RUSTFLAGS="-D warnings"
 
-cargo test --release --all-features
-cargo test --release --all-features -- --ignored
+cargo test --release --features weak,internal-test-strategies,experimental-strategies
+cargo test --release --features weak,internal-test-strategies,experimental-strategies -- --ignored

--- a/src/access.rs
+++ b/src/access.rs
@@ -83,11 +83,12 @@
 //! // Passing a constant that can't change. Useful mostly for testing purposes.
 //! work_with_usize(Constant(42)).join().unwrap();
 //! ```
+use core::marker::PhantomData;
+use core::ops::Deref;
 
-use std::marker::PhantomData;
-use std::ops::Deref;
-use std::rc::Rc;
-use std::sync::Arc;
+use alloc::boxed::Box;
+use alloc::rc::Rc;
+use alloc::sync::Arc;
 
 use super::ref_cnt::RefCnt;
 use super::strategy::Strategy;

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -272,7 +272,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
+    use alloc::sync::Arc;
 
     use super::*;
     use crate::{ArcSwap, ArcSwapOption};

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -6,8 +6,8 @@
 //!
 //! [Arc]: std::sync::Arc
 
-use std::ops::Deref;
-use std::sync::atomic::Ordering;
+use core::ops::Deref;
+use core::sync::atomic::Ordering;
 
 use super::ref_cnt::RefCnt;
 use super::strategy::Strategy;

--- a/src/debt/fast.rs
+++ b/src/debt/fast.rs
@@ -14,9 +14,9 @@
 //! before the change and before any cleanup of the old pointer happened (in which case we know the
 //! writer will see our debt).
 
-use std::cell::Cell;
-use std::slice::Iter;
-use std::sync::atomic::Ordering::*;
+use core::cell::Cell;
+use core::slice::Iter;
+use core::sync::atomic::Ordering::*;
 
 use super::Debt;
 

--- a/src/debt/helping.rs
+++ b/src/debt/helping.rs
@@ -106,10 +106,10 @@
 //!   writer and that change is the destruction ‒ by that time, the destroying thread has exclusive
 //!   ownership and therefore there can be no new readers.
 
-use std::cell::Cell;
-use std::ptr;
-use std::sync::atomic::Ordering::*;
-use std::sync::atomic::{AtomicPtr, AtomicUsize};
+use core::cell::Cell;
+use core::ptr;
+use core::sync::atomic::Ordering::*;
+use core::sync::atomic::{AtomicPtr, AtomicUsize};
 
 use super::Debt;
 use crate::RefCnt;

--- a/src/debt/list.rs
+++ b/src/debt/list.rs
@@ -355,7 +355,7 @@ mod tests {
     impl Node {
         fn is_empty(&self) -> bool {
             self.fast_slots()
-                .chain(std::iter::once(self.helping_slot()))
+                .chain(core::iter::once(self.helping_slot()))
                 .all(|d| d.0.load(Relaxed) == Debt::NONE)
         }
 

--- a/src/debt/list.rs
+++ b/src/debt/list.rs
@@ -33,7 +33,7 @@ use core::sync::atomic::Ordering::*;
 use core::sync::atomic::{AtomicPtr, AtomicUsize};
 
 #[cfg(feature = "experimental-thread-local")]
-use core::cell::RefCell;
+use core::cell::OnceCell;
 
 use alloc::boxed::Box;
 
@@ -250,8 +250,7 @@ impl LocalNode {
 
     #[cfg(feature = "experimental-thread-local")]
     pub(crate) fn with<R, F: FnOnce(&LocalNode) -> R>(f: F) -> R {
-        let mut thread_head_opt = THREAD_HEAD.borrow_mut();
-        let thread_head = thread_head_opt.get_or_insert_with(|| LocalNode {
+        let thread_head = THREAD_HEAD.get_or_init(|| LocalNode {
             node: Cell::new(None),
             fast: FastLocal::default(),
             helping: HelpingLocal::default(),
@@ -346,7 +345,7 @@ thread_local! {
 #[cfg(feature = "experimental-thread-local")]
 #[thread_local]
 /// A debt node assigned to this thread.
-static THREAD_HEAD: RefCell<Option<LocalNode>> = RefCell::new(None);
+static THREAD_HEAD: OnceCell<LocalNode> = OnceCell::new();
 
 #[cfg(test)]
 mod tests {

--- a/src/debt/list.rs
+++ b/src/debt/list.rs
@@ -32,7 +32,7 @@ use core::slice::Iter;
 use core::sync::atomic::Ordering::*;
 use core::sync::atomic::{AtomicPtr, AtomicUsize};
 
-#[cfg(feature = "no-std")]
+#[cfg(feature = "experimental-thread-local")]
 use core::cell::LazyCell;
 
 use alloc::boxed::Box;
@@ -219,7 +219,7 @@ pub(crate) struct LocalNode {
 }
 
 impl LocalNode {
-    #[cfg(not(feature = "no-std"))]
+    #[cfg(not(feature = "experimental-thread-local"))]
     pub(crate) fn with<R, F: FnOnce(&LocalNode) -> R>(f: F) -> R {
         let f = Cell::new(Some(f));
         THREAD_HEAD
@@ -248,7 +248,7 @@ impl LocalNode {
             })
     }
 
-    #[cfg(feature = "no-std")]
+    #[cfg(feature = "experimental-thread-local")]
     pub(crate) fn with<R, F: FnOnce(&LocalNode) -> R>(f: F) -> R {
         if THREAD_HEAD.node.get().is_none() {
             THREAD_HEAD.node.set(Some(Node::get()));
@@ -327,7 +327,7 @@ impl Drop for LocalNode {
     }
 }
 
-#[cfg(not(feature = "no-std"))]
+#[cfg(not(feature = "experimental-thread-local"))]
 thread_local! {
     /// A debt node assigned to this thread.
     static THREAD_HEAD: LocalNode = LocalNode {
@@ -337,7 +337,7 @@ thread_local! {
     };
 }
 
-#[cfg(feature = "no-std")]
+#[cfg(feature = "experimental-thread-local")]
 #[thread_local]
 /// A debt node assigned to this thread.
 static THREAD_HEAD: LazyCell<LocalNode> = LazyCell::new(|| LocalNode {

--- a/src/debt/list.rs
+++ b/src/debt/list.rs
@@ -251,16 +251,11 @@ impl LocalNode {
     #[cfg(feature = "experimental-thread-local")]
     pub(crate) fn with<R, F: FnOnce(&LocalNode) -> R>(f: F) -> R {
         let mut thread_head_opt = THREAD_HEAD.borrow_mut();
-        if thread_head_opt.is_none() {
-            *thread_head_opt = Some(LocalNode {
-                node: Cell::new(None),
-                fast: FastLocal::default(),
-                helping: HelpingLocal::default(),
-            });
-        }
-        let thread_head = thread_head_opt
-            .as_mut()
-            .expect("THREAD_HEAD should not be None");
+        let thread_head = thread_head_opt.get_or_insert_with(|| LocalNode {
+            node: Cell::new(None),
+            fast: FastLocal::default(),
+            helping: HelpingLocal::default(),
+        });
         if thread_head.node.get().is_none() {
             thread_head.node.set(Some(Node::get()));
         }

--- a/src/debt/mod.rs
+++ b/src/debt/mod.rs
@@ -116,7 +116,7 @@ impl Debt {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
+    use alloc::sync::Arc;
 
     /// Checks the assumption that arcs to ZSTs have different pointer values.
     #[test]

--- a/src/debt/mod.rs
+++ b/src/debt/mod.rs
@@ -14,8 +14,8 @@
 //! Each node has some fast (but fallible) nodes and a fallback node, with different algorithms to
 //! claim them (see the relevant submodules).
 
-use std::sync::atomic::AtomicUsize;
-use std::sync::atomic::Ordering::*;
+use core::sync::atomic::AtomicUsize;
+use core::sync::atomic::Ordering::*;
 
 pub(crate) use self::list::{LocalNode, Node};
 use super::RefCnt;
@@ -96,7 +96,7 @@ impl Debt {
 
                 let all_slots = node
                     .fast_slots()
-                    .chain(std::iter::once(node.helping_slot()));
+                    .chain(core::iter::once(node.helping_slot()));
                 for slot in all_slots {
                     // Note: Release is enough even here. That makes sure the increment is
                     // visible to whoever might acquire on this slot and can't leak below this.

--- a/src/docs/mod.rs
+++ b/src/docs/mod.rs
@@ -21,6 +21,19 @@
 //! **are not** part of the API stability guarantees and they may be changed, renamed or removed at
 //! any time.
 //!
+//! The `experimental-thread-local` feature can be used to build arc-swap for `no_std` targets, by
+//! replacing occurences of [`std::thread_local!`] with the `#[thread_local]` directive. This
+//! requires a nightly Rust compiler as it makes use of the experimental
+//! [`thread_local`](https://doc.rust-lang.org/unstable-book/language-features/thread-local.html)
+//! feature. Using this features, thread-local variables are compiled using LLVM built-ins, which
+//! have [several underlying modes of
+//! operation](https://doc.rust-lang.org/beta/unstable-book/compiler-flags/tls-model.html).  To add
+//! support for thread-local variables on a platform that does not have OS or linker support, the
+//! easiest way is to use `-Ztls-model=emulated` and to implement `__emutls_get_address` by hand,
+//! as in [this
+//! example](https://opensource.apple.com/source/clang/clang-800.0.38/src/projects/compiler-rt/lib/builtins/emutls.c.auto.html)
+//! from Clang.
+//!
 //! # Minimal compiler version
 //!
 //! The `1` versions will compile on all compilers supporting the 2018 edition. Note that this

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,6 @@
 #![allow(deprecated)]
 #![cfg_attr(feature = "experimental-thread-local", no_std)]
 #![cfg_attr(feature = "experimental-thread-local", feature(thread_local))]
-#![cfg_attr(feature = "experimental-thread-local", feature(lazy_cell))]
 
 //! Making [`Arc`][Arc] itself atomic
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,9 +2,9 @@
 #![warn(missing_docs)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![allow(deprecated)]
-#![cfg_attr(feature = "no-std", no_std)]
-#![cfg_attr(feature = "no-std", feature(thread_local))]
-#![cfg_attr(feature = "no-std", feature(lazy_cell))]
+#![cfg_attr(feature = "experimental-thread-local", no_std)]
+#![cfg_attr(feature = "experimental-thread-local", feature(thread_local))]
+#![cfg_attr(feature = "experimental-thread-local", feature(lazy_cell))]
 
 //! Making [`Arc`][Arc] itself atomic
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,9 @@
 #![warn(missing_docs)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![allow(deprecated)]
+#![cfg_attr(feature = "no-std", no_std)]
+#![cfg_attr(feature = "no-std", feature(thread_local))]
+#![cfg_attr(feature = "no-std", feature(lazy_cell))]
 
 //! Making [`Arc`][Arc] itself atomic
 //!
@@ -122,6 +125,10 @@
 //!
 //! [RwLock]: https://doc.rust-lang.org/std/sync/struct.RwLock.html
 
+#[allow(unused_imports)]
+#[macro_use]
+extern crate alloc;
+
 pub mod access;
 mod as_raw;
 pub mod cache;
@@ -135,14 +142,15 @@ pub mod strategy;
 #[cfg(feature = "weak")]
 mod weak;
 
-use std::borrow::Borrow;
-use std::fmt::{Debug, Display, Formatter, Result as FmtResult};
-use std::marker::PhantomData;
-use std::mem;
-use std::ops::Deref;
-use std::ptr;
-use std::sync::atomic::{AtomicPtr, Ordering};
-use std::sync::Arc;
+use core::borrow::Borrow;
+use core::fmt::{Debug, Display, Formatter, Result as FmtResult};
+use core::marker::PhantomData;
+use core::mem;
+use core::ops::Deref;
+use core::ptr;
+use core::sync::atomic::{AtomicPtr, Ordering};
+
+use alloc::sync::Arc;
 
 use crate::access::{Access, Map};
 pub use crate::as_raw::AsRaw;
@@ -797,7 +805,7 @@ pub type IndependentArcSwap<T> = ArcSwapAny<Arc<T>, IndependentStrategy>;
 ///
 /// [Weak]: std::sync::Weak
 #[cfg(feature = "weak")]
-pub type ArcSwapWeak<T> = ArcSwapAny<std::sync::Weak<T>>;
+pub type ArcSwapWeak<T> = ArcSwapAny<alloc::sync::Weak<T>>;
 
 macro_rules! t {
     ($name: ident, $strategy: ty) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -810,8 +810,10 @@ macro_rules! t {
     ($name: ident, $strategy: ty) => {
         #[cfg(test)]
         mod $name {
-            use std::panic;
-            use std::sync::atomic::{self, AtomicUsize};
+            use alloc::borrow::ToOwned;
+            use alloc::string::String;
+            use alloc::vec::Vec;
+            use core::sync::atomic::{self, AtomicUsize};
 
             use adaptive_barrier::{Barrier, PanicMode};
             use crossbeam_utils::thread;
@@ -1126,7 +1128,9 @@ macro_rules! t {
 
             /// A panic from within the rcu callback should not change anything.
             #[test]
+            #[cfg(not(feature = "experimental-thread-local"))]
             fn rcu_panic() {
+                use std::panic;
                 let shared = ArcSwap::from(Arc::new(0));
                 assert!(panic::catch_unwind(|| shared.rcu(|_| -> usize { panic!() })).is_err());
                 assert_eq!(1, Arc::strong_count(&shared.swap(Arc::new(42))));
@@ -1244,6 +1248,8 @@ mod internal_strategies {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    use alloc::vec::Vec;
 
     /// Accessing the value inside ArcSwap with Guards (and checks for the reference
     /// counts).

--- a/src/ref_cnt.rs
+++ b/src/ref_cnt.rs
@@ -1,7 +1,8 @@
-use std::mem;
-use std::ptr;
-use std::rc::Rc;
-use std::sync::Arc;
+use core::mem;
+use core::ptr;
+
+use alloc::rc::Rc;
+use alloc::sync::Arc;
 
 /// A trait describing smart reference counted pointers.
 ///
@@ -109,7 +110,7 @@ unsafe impl<T> RefCnt for Arc<T> {
         // possible), so we future-proof it a bit.
 
         // SAFETY: &T cast to *const T will always be aligned, initialised and valid for reads
-        let ptr = Arc::into_raw(unsafe { std::ptr::read(me) });
+        let ptr = Arc::into_raw(unsafe { ptr::read(me) });
         let ptr = ptr as *mut T;
 
         // SAFETY: We got the pointer from into_raw just above
@@ -144,7 +145,7 @@ unsafe impl<T> RefCnt for Rc<T> {
         // possible), so we future-proof it a bit.
 
         // SAFETY: &T cast to *const T will always be aligned, initialised and valid for reads
-        let ptr = Rc::into_raw(unsafe { std::ptr::read(me) });
+        let ptr = Rc::into_raw(unsafe { ptr::read(me) });
         let ptr = ptr as *mut T;
 
         // SAFETY: We got the pointer from into_raw just above

--- a/src/strategy/hybrid.rs
+++ b/src/strategy/hybrid.rs
@@ -13,12 +13,12 @@
 //! See the [crate::debt] module for the actual slot manipulation. Here we just wrap them into the
 //! strategy.
 
-use std::borrow::Borrow;
-use std::mem::{self, ManuallyDrop};
-use std::ops::Deref;
-use std::ptr;
-use std::sync::atomic::AtomicPtr;
-use std::sync::atomic::Ordering::*;
+use core::borrow::Borrow;
+use core::mem::{self, ManuallyDrop};
+use core::ops::Deref;
+use core::ptr;
+use core::sync::atomic::AtomicPtr;
+use core::sync::atomic::Ordering::*;
 
 use super::sealed::{CaS, InnerStrategy, Protected};
 use crate::debt::{Debt, LocalNode};

--- a/src/strategy/mod.rs
+++ b/src/strategy/mod.rs
@@ -43,7 +43,10 @@ use crate::ref_cnt::RefCnt;
 
 pub(crate) mod hybrid;
 
-#[cfg(all(feature = "internal-test-strategies", feature = "experimental-thread-local"))]
+#[cfg(all(
+    feature = "internal-test-strategies",
+    feature = "experimental-thread-local"
+))]
 compile_error!("experimental-thread-local is incompatible with internal-test-strategies as it enables #[no_std]");
 
 #[cfg(feature = "internal-test-strategies")]

--- a/src/strategy/mod.rs
+++ b/src/strategy/mod.rs
@@ -36,12 +36,13 @@
 //! [`ArcSwap`]: crate::ArcSwap
 //! [`load`]: crate::ArcSwapAny::load
 
-use std::borrow::Borrow;
-use std::sync::atomic::AtomicPtr;
+use core::borrow::Borrow;
+use core::sync::atomic::AtomicPtr;
 
 use crate::ref_cnt::RefCnt;
 
 pub(crate) mod hybrid;
+#[cfg(not(feature = "no-std"))]
 mod rw_lock;
 // Do not use from outside of the crate.
 #[cfg(feature = "internal-test-strategies")]

--- a/src/strategy/mod.rs
+++ b/src/strategy/mod.rs
@@ -42,7 +42,7 @@ use core::sync::atomic::AtomicPtr;
 use crate::ref_cnt::RefCnt;
 
 pub(crate) mod hybrid;
-#[cfg(not(feature = "no-std"))]
+#[cfg(not(feature = "experimental-thread-local"))]
 mod rw_lock;
 // Do not use from outside of the crate.
 #[cfg(feature = "internal-test-strategies")]

--- a/src/strategy/mod.rs
+++ b/src/strategy/mod.rs
@@ -42,7 +42,7 @@ use core::sync::atomic::AtomicPtr;
 use crate::ref_cnt::RefCnt;
 
 pub(crate) mod hybrid;
-#[cfg(not(feature = "experimental-thread-local"))]
+#[cfg(feature = "internal-test-strategies")]
 mod rw_lock;
 // Do not use from outside of the crate.
 #[cfg(feature = "internal-test-strategies")]

--- a/src/strategy/mod.rs
+++ b/src/strategy/mod.rs
@@ -42,6 +42,10 @@ use core::sync::atomic::AtomicPtr;
 use crate::ref_cnt::RefCnt;
 
 pub(crate) mod hybrid;
+
+#[cfg(all(feature = "internal-test-strategies", feature = "experimental-thread-local"))]
+compile_error!("experimental-thread-local is incompatible with internal-test-strategies as it enables #[no_std]");
+
 #[cfg(feature = "internal-test-strategies")]
 mod rw_lock;
 // Do not use from outside of the crate.

--- a/src/strategy/rw_lock.rs
+++ b/src/strategy/rw_lock.rs
@@ -1,4 +1,5 @@
-use std::sync::atomic::{AtomicPtr, Ordering};
+use core::sync::atomic::{AtomicPtr, Ordering};
+
 use std::sync::RwLock;
 
 use super::sealed::{CaS, InnerStrategy, Protected};

--- a/src/weak.rs
+++ b/src/weak.rs
@@ -59,7 +59,7 @@ macro_rules! t {
     ($name: ident, $strategy: ty) => {
         #[cfg(test)]
         mod $name {
-            use std::sync::{Arc, Weak};
+            use alloc::sync::{Arc, Weak};
 
             use crate::ArcSwapAny;
 

--- a/src/weak.rs
+++ b/src/weak.rs
@@ -1,6 +1,7 @@
-use std::ptr;
-use std::rc::Weak as RcWeak;
-use std::sync::Weak;
+use core::ptr;
+
+use alloc::rc::Weak as RcWeak;
+use alloc::sync::Weak;
 
 use crate::RefCnt;
 


### PR DESCRIPTION
This PR proposes a non-invasive, relatively minimal implementation of `no_std` support for the `arc-swap` crate. **The aim of this PR is to enable `no_std` without much effort for specific use-cases such as embedded or os dev, which are often already using a nightly compiler anyways, without disturbing the existing functionning of the crate.** I saw the previous PR for no_std support (#56) which was not merged due to lack of activity. If possible I'd like to do the necessary work so that we can have no_std support in arc-swap soon.

- This PR is minimally invaisve: if the `no-std` feature is not enabled then the build is pretty much exactly the same. The crate could successfully be compiled with Rust as low as `v1.38.0` (same as before, see below).

- Compiling with the `no-std` feature requires a nightly Rust compiler, due to the use of unstable features `thread_local` and `lazy_cell`. No additionnal dependencies are added. Suppor for `RwLock` is dropped in `no_std` mode.

- This PR does not require additionnal OS dependencies and does not introducing more locking or synchronization points (it doesn't use the `static_init` crate as in #56). Due to lesser requirements, it is probably usefull on more platforms than #56, as long as support for compiler-generated thread local variables is available. FWIW, the [`tls-mode=emulated`](https://doc.rust-lang.org/beta/unstable-book/compiler-flags/tls-model.html) makes it quite easy to add support for these thread-local variables on a variety of platforms even without OS/kernel support, without having to delve into the intricacies of linkers and symbol relocation ([example in C from the Clang source code](https://opensource.apple.com/source/clang/clang-800.0.38/src/projects/compiler-rt/lib/builtins/emutls.c.auto.html)).

To answer questions from the other thread (PR #56):

> First of all, how lock-free is the library for thread-local storage and initialization? I think it would be OK for it to have some locks on the first access in each thread, or on thread creation. But it would kind of beat the whole purpose of arc-swap if there was a lock in each access. Did you have a chance to study the documentation or implementation?

In this PR, we are using only the experimental `#[thread_local]` tag of the nightly compiler. This compiles down to LLVM thread local primitives, which are supposedly one of the fastest possible underlying implementation for std's `thread_local!` macro, so no performance penalty on that side is to be expected. Custom implementations can also be made easily without locks. The thread local variable itself that is used by `arc-swap` is a `LazyCell` which is not `Sync`, so there is no mutex or synchronizaton penalty on initialization.

>  Without enabling the new feature, all previous features need to compile as previously. Specifically, with no features enabled, it must be possible to compile even with 1.31.0.

This is the case with this PR, albeit the lowest supported version is 1.38.0, which is not related to changes in this PR. Versions <=1.37.0 failed with the following error, which was already the case on the master branch:

```
error: failed to parse lock file at: /home/lx/dev/crates/arc-swap/Cargo.lock

Caused by:
  invalid serialized PackageId for key `package.dependencies`
```

>  I believe this new feature doesn't have to be incompatible with the weak feature.

Not an issue in this PR.

> I also believe the new feature should be compatible with stable rust, not work only on nightly.

Unfortunately, this is not doable easily in the current state of the Rust ecosystem, at least not with a lot of additional effort. This PR is a minimal try to land `no_std` support in the `arc-swap` crate as simply as possible, so it naturally comes with some restriction. I tried to have as little restrictions as possible, and basically there are only two conditions for this to be used: use a nightly compiler, and have support for compiler-generated thread local variables.

I'd be glad to have your comments and advice on how we can make this into something that can be merged into `arc-swap`.