### PR TITLE
Fix feature list for docs.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ serde_test = "1.0.130"
 debug = true
 
 [package.metadata.docs.rs]
-all-features = true
+features = ["serde", "weak"]
 
 [[bench]]
 name = "background"


### PR DESCRIPTION
Previously, docs.rs would try to build with all features, but we now have exclusive features (internal-test-strategies vs. experimental-thread-local) which breaks the build. This fixes the build by not documenting with the experimental-thread-local feature.