### PR TITLE
docs: Revise confusing wording in docs

### DIFF
--- a/src/docs/performance.rs
+++ b/src/docs/performance.rs
@@ -5,8 +5,8 @@
 //! ## Lock-free readers
 //!
 //! All the read operations are always [lock-free]. Most of the time, they are actually
-//! [wait-free]. They are [lock-free] from time to time, with at least `usize::MAX / 4` accesses
-//! that are [wait-free] in between.
+//! [wait-free]. They may wait from time to time, with at least `usize::MAX / 4` [wait-free]
+//! accesses in between waits.
 //!
 //! Writers are [lock-free].
 //!


### PR DESCRIPTION
My attempt to address issue #150 

The prior wording simultaneously stated that

1. All read operations are lock-free
2. Read operations are lock-free from time to time.

I'm actually still not clear if this revised wording is correct.

For one thing, the claim _seems_ incredible.

Assuming that `usize::MAX` is $2^{64} - 1$, and assuming I read one-billion times per second, then it will take 

```math
\frac{\left(2^{64} - 1\right) \cdot \mathrm{access}}{4}  \cdot \frac{\mathrm{1 \cdot second}}{10^9 \cdot \mathrm{access}} \cdot \frac{ 1 \cdot \mathrm{minute} }{ 60 \cdot \mathrm{second}} \cdot  \frac{ 1 \cdot \mathrm{hour} }{ 60 \cdot \mathrm{minute}} \cdot \frac{ 1 \cdot \mathrm{day} }{ 24 \cdot \mathrm{hour} } \cdot \frac{1 \cdot \mathrm{year} }{365.25 \cdot \mathrm{day} } = 146.13 \cdot \mathrm{year}
```

_at minimum_ before I have a wait operation.

I don't understand that statement at all, which is why I suspect that this PR should either be rejected or modified after discussion.