### PR TITLE
Update benchmarks link to correct GitHub workflows path

### DIFF
--- a/src/docs/performance.rs
+++ b/src/docs/performance.rs
@@ -82,6 +82,6 @@
 //! [`Arc`]: std::sync::Arc
 //! [`Mutex`]: std::sync::Mutex
 //! [`RwLock`]: std::sync::RwLock
-//! [benchmarks]: https://github.com/vorner/arc-swap/tree/master/benchmarks
+//! [benchmarks]: https://github.com/vorner/arc-swap/blob/master/.github/workflows/benchmarks.yaml
 //! [lock-free]: https://en.wikipedia.org/wiki/Non-blocking_algorithm#Lock-freedom
 //! [wait-free]: https://en.wikipedia.org/wiki/Non-blocking_algorithm#Wait-freedom


### PR DESCRIPTION


Changes made:
File: src/docs/performance.rs
- Old: //! [benchmarks]: https://github.com/vorner/arc-swap/tree/master/benchmarks
+ New: //! [benchmarks]: https://github.com/vorner/arc-swap/blob/master/.github/workflows/benchmarks.yaml

Reason for changes:
Updating the benchmarks documentation link to point to the correct location in the GitHub workflows directory where the benchmarks configuration is actually stored.