### PR TITLE
Fix fast load when allocation is reused

### DIFF
--- a/src/strategy/hybrid.rs
+++ b/src/strategy/hybrid.rs
@@ -51,7 +51,10 @@ impl<T: RefCnt> HybridProtection<T> {
         let confirm = storage.load(SeqCst);
         if ptr == confirm {
             // Successfully got a debt
-            Some(unsafe { Self::new(ptr, Some(debt)) })
+            // NOTE: we *must* use `confirm` here instead of `ptr`. The address may compare equal,
+            // but they could have different provenance, if the pointer is freed and then
+            // subsequently reused.
+            Some(unsafe { Self::new(confirm, Some(debt)) })
         } else if debt.pay::<T>(ptr) {
             // It changed in the meantime, we return the debt (that is on the outdated pointer,
             // possibly destroyed) and fail.


### PR DESCRIPTION
Fix #156 

The issue was due to allocation being reused, and `arc-swap` makes use the old pointer which was freed (and thus carries the wrong provenance). 

Without this change, the MIRI fires very reliably under high pool reuse rate (e.g. `-Zmiri-address-reuse-rate=0.9`), but it no longer fires with this PR.

This is unlikely to affect actual codegen as there is a control dependency from this pointer use and the compare, so compiler is unlikely to do something crazy. So unfortunately this is unlikely to fix <!-- --> #164.