### PR TITLE
Fix use-after-free in fallback path: storage.load needs SeqCst

### DIFF
--- a/src/strategy/hybrid.rs
+++ b/src/strategy/hybrid.rs
@@ -71,10 +71,11 @@ impl<T: RefCnt> HybridProtection<T> {
         // First, we claim a debt slot and store the address of the atomic pointer there, so the
         // writer can optionally help us out with loading and protecting something.
         let gen = node.new_helping(storage as *const _ as usize);
-        // We already synchronized the start of the sequence by SeqCst in the new_helping vs swap on
-        // the pointer. We just need to make sure to bring the pointee in (this can be newer than
-        // what we got in the Debt)
-        let candidate = storage.load(Acquire);
+        // SeqCst is needed here (not just Acquire) so this load participates in the
+        // single total order with the writer's SeqCst swap on the same variable.
+        // With Acquire, this load can return a stale pointer that the writer has
+        // already replaced and freed, leading to use-after-free.
+        let candidate = storage.load(SeqCst);
 
         // Try to replace the debt with our candidate. If it works, we get the debt slot to use. If
         // not, we get a replacement value, already protected and a debt to take care of.

--- a/tests/fallback_uaf.rs
+++ b/tests/fallback_uaf.rs
@@ -1,0 +1,27 @@
+use std::sync::Arc;
+use std::thread;
+
+#[allow(deprecated)]
+use arc_swap::strategy::test_strategies::FillFastSlots;
+use arc_swap::ArcSwapAny;
+
+type FallbackSwap<T> = ArcSwapAny<Arc<T>, FillFastSlots>;
+
+/// Triggers UAF under miri on aarch64 (e.g. seed=39) when storage.load uses
+/// Acquire instead of SeqCst in the fallback path.
+#[test]
+fn fallback_rcu() {
+    const ITERS: usize = 20;
+    const THREADS: usize = 4;
+    let shared = FallbackSwap::<usize>::new(Arc::new(0));
+    thread::scope(|scope| {
+        for _ in 0..THREADS {
+            scope.spawn(|| {
+                for _ in 0..ITERS {
+                    shared.rcu(|old| **old + 1);
+                }
+            });
+        }
+    });
+    assert_eq!(THREADS * ITERS, **shared.load());
+}


### PR DESCRIPTION
`storage.load(Acquire)` in `HybridProtection::fallback` can return a stale pointer. Upgrade to `SeqCst`.

### Problem

```rust
let gen = node.new_helping(storage as *const _ as usize); // SeqCst
let candidate = storage.load(Acquire); // <- not in the SeqCst total order
```

A concurrent writer can `storage.swap(new_ptr, SeqCst)`, but this `Acquire` load may still see the old pointer. The writer scans, sees no debt yet, frees the old pointer. Reader gets a dangling pointer.


### Miri reproduction

Test uses `FillFastSlots` to isolate the fallback path from fast-path ordering.

```
MIRIFLAGS="-Zmiri-seed=39 -Zmiri-preemption-rate=1" \
  cargo +nightly miri test --features internal-test-strategies \
  --target aarch64-unknown-linux-gnu --test fallback_uaf
```

Before (`Acquire`): seed=39, seed=77 fail.
After (`SeqCst`): seeds 0–100 all pass.
