### PR TITLE
Fix CI compatibility with current tooling

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -28,11 +28,13 @@ jobs:
       - name: Restore cache
         uses: Swatinem/rust-cache@v2
 
-      - name: Run cargo-tarpaulin
-        uses: actions-rs/tarpaulin@v0.1
+      - name: Install cargo-tarpaulin
+        uses: taiki-e/install-action@v2
         with:
-          args: '--features weak,internal-test-strategies,experimental-strategies --run-types Doctests,Tests'
-          timeout: 120
+          tool: cargo-tarpaulin
+
+      - name: Run cargo-tarpaulin
+        run: cargo tarpaulin --features weak,internal-test-strategies,experimental-strategies --run-types Doctests --run-types Tests --timeout 120 --out Xml
 
       - name: Upload to codecov.io
         uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -173,6 +173,8 @@ jobs:
   semi-ancient:
     name: Check it compiles on old Rust (1.45.0)
     runs-on: ubuntu-latest
+    env:
+      CARGO_NET_GIT_FETCH_WITH_CLI: "true"
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -193,6 +195,8 @@ jobs:
   ancient:
     name: Check it compiles on old Rust (1.31.0)
     runs-on: ubuntu-latest
+    env:
+      CARGO_NET_GIT_FETCH_WITH_CLI: "true"
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -284,7 +288,8 @@ jobs:
         #
         # Running the tests multiple times increase the chances that data races are found
         # by the thread sanitizer.
-        for _ in $(seq 1 10); do cargo +nightly test -Z build-std --target $(uname -m)-apple-darwin; done
+        target="$(rustc +nightly -vV | sed -n 's/^host: //p')"
+        for _ in $(seq 1 10); do cargo +nightly test -Z build-std --target "$target"; done
       env:
         RUSTDOCFLAGS: "-Zsanitizer=thread"
         RUSTFLAGS: "-Zsanitizer=thread"

--- a/tests/bug-198.rs
+++ b/tests/bug-198.rs
@@ -1,4 +1,4 @@
-use std:: sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::thread;
 
 use arc_swap::ArcSwap;
@@ -12,10 +12,15 @@ impl SpinBarrier {
 
     fn wait(&self) {
         self.0.fetch_sub(1, Ordering::Relaxed);
-        while self.0.load(Ordering::Relaxed) != 0 {}
+        while self.0.load(Ordering::Relaxed) != 0 {
+            std::hint::spin_loop();
+        }
     }
 
-    fn wrap<R: Send, F: FnOnce() -> R + Send>(&self, f: F) -> impl FnOnce() -> R + Send + use<'_, R, F> {
+    fn wrap<R: Send, F: FnOnce() -> R + Send>(
+        &self,
+        f: F,
+    ) -> impl FnOnce() -> R + Send + use<'_, R, F> {
         move || {
             self.wait();
             f()


### PR DESCRIPTION
- use CLI git fetches for legacy Cargo jobs
- replace the archived Tarpaulin wrapper and update its arguments
- derive the macOS sanitizer target from rustc's host triple
- satisfy formatting and Clippy checks in the regression 


These changes fix the CI build.